### PR TITLE
Fix progress accuracy in batch converter

### DIFF
--- a/app/services/converter.py
+++ b/app/services/converter.py
@@ -616,7 +616,7 @@ class ConversionService:
         for i, file_info in enumerate(files):
             try:
                 # Update progress (this would typically update Redis/database)
-                progress = int((i / len(files)) * 100)
+                progress = int(((i + 1) / len(files)) * 100)
                 current_app.logger.debug(f"Job {job_id} progress: {progress}%")
                 
                 # Convert single file


### PR DESCRIPTION
## Summary
- adjust progress percentage calculation during batch conversions

## Testing
- `python3 -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6845250e2a8c8320a4bc22347e69b527