### PR TITLE
Fix README brew command for RAR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Quick install for macOS:
 
 # Install system dependencies
 brew install freetype imagemagick ffmpeg libreoffice pandoc ghostscript p7zip
-brew install homebrew/cask/unrar
+brew install unar
 ```
 
 For other operating systems, please refer to [system_requirements.md](system_requirements.md).


### PR DESCRIPTION
## Summary
- change macOS quick install instructions to use `unar`

## Testing
- `python scripts/check_dependencies.py` *(fails: ImageMagick, FFmpeg, LibreOffice, 7-Zip, UnRAR not found, and several Python packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_684526b6629483208b6a9e55bb41d703