### PR TITLE
Fix output format selection

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -112,7 +112,7 @@
             <div class="format-selection" id="format-selection" style="display: none;">
                 <h3 class="format-selection-title">Choose Output Format</h3>
                 
-                <div class="format-categories">
+                <div id="format-categories" class="format-categories">
                     {% for category, formats in supported_formats.items() %}
                     <div class="format-category">
                         <div class="category-header">


### PR DESCRIPTION
## Summary
- fix incorrect container id for format categories so JS can populate options

## Testing
- `flake8 .` *(fails: many style violations)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68452ca596a883208605cba3a3b70697